### PR TITLE
Add demo

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,10 +7,16 @@ roslaunch phidget_stepper launch_motor.launch
 ```
 This will fire up two motor instances suscribing to topic `/motor_config`, the message type can be seen by `rosmsg show StepperConfig`
 
+## How to run motor demo
+
+```
+roslaunch phidget_stepper demo_motor.launch
+```
+
 ## Note
 - Make sure you add `export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/usr/local/lib` to `~/.bashrc` file before running `roslaunch`
 
 ## Future work
 
 - Seperate phidget library and ROS wrapper
-- Make a test script to show how to use the node
+- ~~Make a test script to show how to use the node~~

--- a/demos/demo_commands.py
+++ b/demos/demo_commands.py
@@ -1,0 +1,28 @@
+#!/usr/bin/env python
+
+import rospy
+from phidget_stepper.msg import StepperConfig
+def talker():
+    pub = rospy.Publisher("motor_config", StepperConfig, queue_size=10)
+    rospy.init_node('motor_test', anonymous=True)
+    rate = rospy.Rate(1) # 2hz
+
+    while not rospy.is_shutdown():
+        leftCmd = StepperConfig()
+        leftCmd.toLeft = True
+        leftCmd.engage = True #True for sending  power to motor coils (make it move)
+        leftCmd.mode = True #True
+        leftCmd.velocityLimit =  float(20)
+        leftCmd.acceleration = float(100)
+        leftCmd.position = int(1500)
+
+        print("sent it boss")
+        pub.publish(leftCmd)
+        rate.sleep()
+
+
+if __name__ == '__main__':
+    try:
+        talker()
+    except rospy.ROSInterruptException:
+        pass

--- a/demos/demo_motor.launch
+++ b/demos/demo_motor.launch
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no" ?>
+<launch>
+  
+  <include file="$(find phidget_stepper)/launch/launch_motor.launch"/>
+
+  <node name="commandTest" pkg="phidget_stepper" type="demo_commands.py" output="screen"/>
+
+</launch>

--- a/launch/launch_motor.launch
+++ b/launch/launch_motor.launch
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no" ?>
 <launch>
+  
   <node name="stepper_left" pkg="phidget_stepper" type="stepper.py" output="screen">
     <rosparam param="isLeft">true</rosparam>
     <rosparam param="serialId">420520</rosparam>
@@ -10,6 +11,4 @@
     <rosparam param="serialId">420519</rosparam>
   </node>
 
-  <node name="motorTest" pkg="motor_test" type="test.py" output="screen">
-  </node>
 </launch>

--- a/launch/launch_motor.launch
+++ b/launch/launch_motor.launch
@@ -9,4 +9,7 @@
     <rosparam param="isLeft">false</rosparam>
     <rosparam param="serialId">420519</rosparam>
   </node>
+
+  <node name="motorTest" pkg="motor_test" type="test.py" output="screen">
+  </node>
 </launch>

--- a/scripts/stepper.py
+++ b/scripts/stepper.py
@@ -2,7 +2,7 @@
 import rospy
 from phidget_stepper.msg import StepperConfig
 
-import time 
+import time
 from Phidget22.Devices.Stepper import *
 from Phidget22.PhidgetException import *
 from Phidget22.Phidget import *
@@ -32,8 +32,9 @@ def StepperAttached(e):
     except PhidgetException as e:
         print("Phidget Exception %i: %s" % (e.code, e.details))
         print("Press Enter to Exit...\n")
-        exit(1)   
-    
+        exit(1)
+
+
 def StepperDetached(e):
     detached = e
     try:
@@ -41,22 +42,28 @@ def StepperDetached(e):
     except PhidgetException as e:
         print("Phidget Exception %i: %s" % (e.code, e.details))
         print("Press Enter to Exit...\n")
-        exit(1)   
+        exit(1)
+
 
 def ErrorEvent(e, eCode, description):
     print("Error %i : %s" % (eCode, description))
 
+
 def PositionChangeHandler(e, position):
     print("Position: %f" % position)
 
+
 def configMotor(conf):
     global ch
+    print("Got em boss")
     if conf.toLeft == rospy.get_param("~isLeft"):
+
         ch.setEngaged(conf.engage)
         ch.setTargetPosition(conf.position)
         ch.setControlMode(conf.mode)
         ch.setAcceleration(conf.acceleration)
         ch.setVelocityLimit(conf.velocityLimit)
+
 
 def closeMotor():
     global ch
@@ -65,8 +72,9 @@ def closeMotor():
     except PhidgetException as e:
         print("Phidget Exception %i: %s" % (e.code, e.details))
         print("Press Enter to Exit...\n")
-        exit(1) 
+        exit(1)
     print("Closed Stepper device")
+
 
 if __name__ == '__main__':
     try:
@@ -94,8 +102,11 @@ if __name__ == '__main__':
 
         # Initialize suscriber node
         rospy.Subscriber("motor_config", StepperConfig, configMotor)
+        #print("Subscriber initialized")
+        # spin() simply keeps python from exiting until this node is stopped
+        rospy.spin()
 
-        rospy.on_shutdown(closeMotor)
 
     except rospy.ROSInterruptException:
+        rospy.on_shutdown(closeMotor)
         pass


### PR DESCRIPTION
## Move Andrew's "testing" code from `motor_test` to this node.
I think `demo` should be a more appropriate name than `test` since it's not a test that can out put "pass" or "fail".
Now all the demo script and launch file are in the `demo` folder. Note that ROS can find the files in any sub-folder,  not only `scripts` or `launch`.